### PR TITLE
docs: adicionar referência aos padrões de desenvolvimento no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,4 +218,8 @@ Este projeto está estruturado para suportar:
 
 ## 📄 Licença
 
-Este projeto está sob a licença MIT. 
+Este projeto está sob a licença MIT.
+
+---
+
+> Este projeto segue os padrões de desenvolvimento descritos em [api-creditos-spring-angular.md](./api-creditos-spring-angular.md). 


### PR DESCRIPTION
## Objetivo
Adicionar uma referência no rodapé do README.md aos padrões de desenvolvimento descritos em api-creditos-spring-angular.md, garantindo alinhamento com a documentação do projeto.

## Tipo de Mudança
- [x] Documentação

## Checklist
- [x] README.md atualizado
- [x] Referência clara aos padrões de desenvolvimento

## Como testar
1. Verifique o rodapé do README.md
2. Confirme a presença do link para api-creditos-spring-angular.md

## Issues relacionadas
Closes #1

## Observações adicionais
Alteração mínima para garantir diferença entre a branch de feature e main, permitindo a criação do PR conforme fluxo padrão.