### PR TITLE
chore(frontend): configurar ESLint e Prettier com scripts e documentação

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,6 +22,17 @@ Gerado com [Angular CLI](https://angular.io/cli) usando:
    ```
 3. Acesse em [http://localhost:4200](http://localhost:4200)
 
+## Lint e Formatação
+
+- **Lint (ESLint):**
+  ```bash
+  npm run lint
+  ```
+- **Formatação (Prettier):**
+  ```bash
+  npm run format
+  ```
+
 ## Estrutura de Pastas
 
 - `src/app/` - Código principal da aplicação
@@ -29,10 +40,9 @@ Gerado com [Angular CLI](https://angular.io/cli) usando:
 - `angular.json` - Configuração do projeto Angular
 
 ## Próximos Passos
-- Configurar ESLint e Prettier
 - Implementar tela de consulta de créditos
 - Adicionar integração com API REST
 - Dockerizar frontend
 
 ---
-> Referência: [Angular Project Setup](https://angular.io/cli/new)
+> Referência: [Angular + ESLint](https://github.com/angular-eslint/angular-eslint)

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -91,8 +91,22 @@
               "src/styles.scss"
             ]
           }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
         }
       }
     }
+  },
+  "cli": {
+    "schematicCollections": [
+      "angular-eslint"
+    ]
   }
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,43 @@
+// @ts-check
+const eslint = require("@eslint/js");
+const tseslint = require("typescript-eslint");
+const angular = require("angular-eslint");
+
+module.exports = tseslint.config(
+  {
+    files: ["**/*.ts"],
+    extends: [
+      eslint.configs.recommended,
+      ...tseslint.configs.recommended,
+      ...tseslint.configs.stylistic,
+      ...angular.configs.tsRecommended,
+    ],
+    processor: angular.processInlineTemplates,
+    rules: {
+      "@angular-eslint/directive-selector": [
+        "error",
+        {
+          type: "attribute",
+          prefix: "app",
+          style: "camelCase",
+        },
+      ],
+      "@angular-eslint/component-selector": [
+        "error",
+        {
+          type: "element",
+          prefix: "app",
+          style: "kebab-case",
+        },
+      ],
+    },
+  },
+  {
+    files: ["**/*.html"],
+    extends: [
+      ...angular.configs.templateRecommended,
+      ...angular.configs.templateAccessibility,
+    ],
+    rules: {},
+  }
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "lint": "ng lint",
+    "format": "prettier --write \"src/**/*.{ts,js,scss,html}\""
   },
   "prettier": {
     "overrides": [
@@ -35,12 +37,16 @@
     "@angular/cli": "^20.0.5",
     "@angular/compiler-cli": "^20.0.0",
     "@types/jasmine": "~5.1.0",
+    "angular-eslint": "20.1.1",
+    "eslint": "^9.29.0",
     "jasmine-core": "~5.7.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.8.2"
+    "prettier": "^3.6.2",
+    "typescript": "~5.8.2",
+    "typescript-eslint": "8.34.1"
   }
 }


### PR DESCRIPTION
## Objetivo
Adicionar e configurar ESLint e Prettier no frontend Angular, garantindo padrão de código consistente e documentação dos comandos no README.

- ESLint configurado via @angular-eslint/schematics
- Prettier instalado e configurado
- Scripts npm para lint e format
- README atualizado com instruções

## Tipo de Mudança
- [x] Chore
- [x] Documentação

## Checklist
- [x] ESLint funcional
- [x] Prettier funcional
- [x] Scripts npm documentados
- [x] Build local executado com sucesso

## Como testar
1. Rode `npm run lint` para verificar o lint
2. Rode `npm run format` para formatar o código

## Issues relacionadas
Closes #42

## Observações adicionais
Padrão de código e formatação garantidos para o frontend.